### PR TITLE
feat(plugins): conditional loading and environment-aware configs

### DIFF
--- a/lua/plugins/fzf.lua
+++ b/lua/plugins/fzf.lua
@@ -1,0 +1,24 @@
+return {
+  "ibhagwan/fzf-lua",
+  opts = {
+    files = {
+      fd_opts = table.concat({
+        "--color=never",
+        "--type=f",
+        "--hidden",
+        "--follow",
+        "--exclude=.git",
+        "--exclude=node_modules",
+        "--exclude=dist",
+        "--exclude=build",
+        "--exclude=.next",
+        "--exclude=.nuxt",
+        "--exclude=coverage",
+        "--exclude=.cache",
+        "--exclude=__pycache__",
+        "--exclude=.venv",
+        "--exclude=vendor",
+      }, " "),
+    },
+  },
+}

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -1,0 +1,12 @@
+local has_go = vim.fn.executable("go") == 1
+
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        gopls = { enabled = has_go },
+      },
+    },
+  },
+}

--- a/lua/plugins/wakatime.lua
+++ b/lua/plugins/wakatime.lua
@@ -2,6 +2,11 @@ return {
   "wakatime/vim-wakatime",
   lazy = false,
   cond = function()
-    return vim.fn.filereadable(vim.fn.expand("~/.wakatime.cfg")) == 1
+    local cfg = vim.fn.expand("~/.wakatime.cfg")
+    if vim.fn.filereadable(cfg) == 0 then
+      return false
+    end
+    local content = table.concat(vim.fn.readfile(cfg), "\n")
+    return content:find("api_key%s*=") ~= nil
   end,
 }


### PR DESCRIPTION
## Summary
- **wakatime**: solo carga cuando `api_key` está presente en `~/.wakatime.cfg`
- **fzf-lua**: excluye `node_modules`, `dist`, `build` y otros directorios generados al buscar archivos
- **lsp**: deshabilita `gopls` cuando `go` no está disponible en el PATH

## Test plan
- [x] Verificar que wakatime no genera error si no hay `api_key` configurada
- [x] Verificar que `<leader>ff` no muestra archivos de `node_modules` o `dist`
- [x] Verificar que Mason no intenta instalar `gopls` en entornos sin Go

🤖 Generated with [Claude Code](https://claude.com/claude-code)