### PR TITLE
feat(colorscheme): add background and variant setup for all colorschemes

### DIFF
--- a/lua/plugins/colorscheme.lua
+++ b/lua/plugins/colorscheme.lua
@@ -1,4 +1,31 @@
 return {
+  { "ellisonleao/gruvbox.nvim", opts = { contrast = "soft" } },
+  {
+    "rebelot/kanagawa.nvim",
+    opts = {
+      theme = "wave",
+      background = { dark = "wave", light = "lotus" },
+    },
+  },
+  {
+    "rose-pine/neovim",
+    name = "rose-pine",
+    opts = {
+      variant = "auto",
+      dark_variant = "main",
+    },
+  },
+  {
+    "neanias/everforest-nvim",
+    version = false,
+    lazy = false,
+    priority = 1000,
+    config = function()
+      require("everforest").setup({
+        background = "medium",
+      })
+    end,
+  },
   {
     "LazyVim/LazyVim",
     opts = {


### PR DESCRIPTION
## Summary
- Configure gruvbox with soft contrast via `opts`
- Configure kanagawa with wave (dark) / lotus (light) variant mapping
- Configure rose-pine with auto variant and main as dark default
- Configure everforest with medium contrast using `config()` to fix module name mismatch (`everforest-nvim` repo vs `everforest` Lua module)

## Test plan
- [ ] Open Neovim — no startup errors, catppuccin-frappe still active
- [ ] `:colorscheme kanagawa` → wave variant applied
- [ ] `:colorscheme rose-pine` → main (dark) variant applied
- [ ] `:colorscheme gruvbox` → soft contrast applied
- [ ] `:colorscheme everforest` → medium contrast, no module error

🤖 Generated with [Claude Code](https://claude.com/claude-code)